### PR TITLE
nmc/2352-ANID shown file browser mount

### DIFF
--- a/.github/workflows/generates_locales.yml
+++ b/.github/workflows/generates_locales.yml
@@ -17,9 +17,9 @@ jobs:
         pre-build-command: pip install -r requirements.txt
         build-command: make gettext
     - uses: actions/checkout@v2
-      - name: Commit report
-        run: |
-          git config --global user.name 'Nextcloud Bot'
-          git config --global user.email 'bot@nextcloud.com'
-          git commit -am "Updates catalog templates (POT files fetched automatically by transifex)"
-          git push
+    - name: Commit report
+      run: |
+        git config --global user.name 'Nextcloud Bot'
+        git config --global user.email 'bot@nextcloud.com'
+        git commit -am "Updates catalog templates (POT files fetched automatically by transifex)"
+        git push

--- a/.github/workflows/generates_locales.yml
+++ b/.github/workflows/generates_locales.yml
@@ -17,9 +17,9 @@ jobs:
         pre-build-command: pip install -r requirements.txt
         build-command: make gettext
     - uses: actions/checkout@v2
-    - name: Commit report
-      run: |
-        git config --global user.name 'Nextcloud Bot'
-        git config --global user.email 'bot@nextcloud.com'
-        git commit -am "Updates catalog templates (POT files fetched automatically by transifex)"
-        git push
+      - name: Commit report
+        run: |
+          git config --global user.name 'Nextcloud Bot'
+          git config --global user.email 'bot@nextcloud.com'
+          git commit -am "Updates catalog templates (POT files fetched automatically by transifex)"
+          git push

--- a/src/gui/navigationpanehelper.cpp
+++ b/src/gui/navigationpanehelper.cpp
@@ -97,8 +97,8 @@ void NavigationPaneHelper::updateCloudStorageRegistry()
 
                 QString title = folder->shortGuiRemotePathOrAppName();
                 // Write the account name in the sidebar only when using more than one account.
-                if (AccountManager::instance()->accounts().size() > 1)
-                    title = title % " - " % folder->accountState()->account()->displayName();
+              //  if (AccountManager::instance()->accounts().size() > 1)
+                    title = title % " - " % folder->accountState()->account()->prettyName();//displayName(); //MagentaCustomizationV25
                 QString iconPath = QDir::toNativeSeparators(qApp->applicationFilePath());
                 QString targetFolderPath = QDir::toNativeSeparators(folder->cleanPath());
 


### PR DESCRIPTION
1. Username will be displayed on file browser mount instead of anid 
2. Removed restriction of showing username for single user account on file browser(Nextcloud allow to show anid/username for multiple users only)

![image](https://github.com/nextmcloud/desktop/assets/110465779/13b39e0d-d7c4-4f3d-8e77-0785228fe6ae)
