### PR TITLE
Customized virtual files encryption

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -99,11 +99,7 @@ void showEnableE2eeWithVirtualFilesWarningDialog(std::function<void(void)> onAcc
     messageBox->setIcon(QMessageBox::Warning);
     const auto dontEncryptButton = messageBox->addButton(QMessageBox::StandardButton::Cancel);
     Q_ASSERT(dontEncryptButton);
-    dontEncryptButton->setText(AccountSettings::tr("Do not encrypt folder"));
-    const auto encryptButton = messageBox->addButton(QMessageBox::StandardButton::Ok);
-    Q_ASSERT(encryptButton);
-    encryptButton->setText(AccountSettings::tr("Encrypt folder"));
-    QObject::connect(messageBox, &QMessageBox::accepted, onAccept);
+    dontEncryptButton->setText(AccountSettings::tr("Cancel"));
 
     messageBox->open();
 }
@@ -402,7 +398,9 @@ void AccountSettings::slotMarkSubfolderEncrypted(FolderStatusModel::SubFolderInf
         job->start();
     };
 
-    if (folder->virtualFilesEnabled() && folder->vfs().mode() == Vfs::WindowsCfApi) {
+    auto const pinState = folder->vfs().pinState(path);
+    if (folder->virtualFilesEnabled() && folder->vfs().mode() == Vfs::WindowsCfApi
+            && (*pinState != PinState::AlwaysLocal)) {
         showEnableE2eeWithVirtualFilesWarningDialog(encryptFolder);
         return;
     }


### PR DESCRIPTION
Fixed virtual files encryption
Virtual should not get encrypted instead we should get message to download files using 'Make Available Always' option.
![Virtual File Encryption Dialog](https://github.com/nextmcloud/desktop/assets/90902670/afeb8a07-7cc0-4ff0-8aa0-f02935ffb38c)
